### PR TITLE
Fix infinite loop over non-visible elements

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -18,7 +18,9 @@ export default class Truncate extends Component {
         lines: 1
     };
 
-    state = {};
+    state = {
+        isVisible: true
+    };
 
     constructor(...args) {
         super(...args);
@@ -137,6 +139,9 @@ export default class Truncate extends Component {
         // If target isn't visible on the page, then it'll start an infinite
         // loop with requestAnimationFrame below
         if (!targetParentVisible) {
+            this.setState({
+                isVisible: false
+            });
             return;
         }
 
@@ -160,7 +165,8 @@ export default class Truncate extends Component {
         canvasContext.font = font;
 
         this.setState({
-            targetWidth
+            targetWidth,
+            isVisible: true
         }, callback);
     }
 

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -134,11 +134,11 @@ export default class Truncate extends Component {
             return;
         }
 
-        const targetParentVisible = target.parentNode.offsetHeight;
+        const targetVisible = target.offsetHeight;
 
         // If target isn't visible on the page, then it'll start an infinite
         // loop with requestAnimationFrame below
-        if (!targetParentVisible) {
+        if (!targetVisible) {
             this.setState({
                 isVisible: false
             });

--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -132,6 +132,14 @@ export default class Truncate extends Component {
             return;
         }
 
+        const targetParentVisible = target.parentNode.offsetHeight;
+
+        // If target isn't visible on the page, then it'll start an infinite
+        // loop with requestAnimationFrame below
+        if (!targetParentVisible) {
+            return;
+        }
+
         const targetWidth = target.parentNode.getBoundingClientRect().width;
 
         // Delay calculation until parent node is inserted to the document

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -109,6 +109,13 @@ describe('<Truncate />', () => {
                 }
             });
 
+            // offset height is always 0 in jsdom world
+            Object.defineProperties(global.window.HTMLDivElement.prototype, {
+                offsetHeight: {
+                    get: function () { return 1; }
+                }
+            });
+
             for (const key in global.window) {
                 if (!global[key]) {
                     global[key] = global.window[key];

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -40,6 +40,7 @@ const expect = unexpected.clone()
 
 const characterWidth = 6; // px
 const measureWidth = text => text.length * characterWidth;
+const offsetHeightStub = sinon.stub().returns(1);
 
 describe('<Truncate />', () => {
     it('should be a React component', () => {
@@ -109,10 +110,10 @@ describe('<Truncate />', () => {
                 }
             });
 
-            // offset height is always 0 in jsdom world
+            // offset height is always 0 in jsdom world, so need to stub it out
             Object.defineProperties(global.window.HTMLDivElement.prototype, {
                 offsetHeight: {
-                    get: function () { return 1; }
+                    get: offsetHeightStub
                 }
             });
 
@@ -121,6 +122,10 @@ describe('<Truncate />', () => {
                     global[key] = global.window[key];
                 }
             }
+        });
+
+        beforeEach(() => {
+            offsetHeightStub.returns(1);
         });
 
         // Mock out a box that's 16 characters wide
@@ -382,6 +387,30 @@ describe('<Truncate />', () => {
                     expect(handleTruncate, 'was called');
                 });
             });
+        });
+
+        it('should set isVisible to false when parent node not visible on page', () => {
+            offsetHeightStub.returns(0);
+
+            const component = renderIntoDocument(
+                <Truncate>
+                    Sample text
+                </Truncate>
+            );
+
+            expect(component.state.isVisible, 'to equal', false);
+        });
+
+        it('should set isVisible to true when parent node not visible on page', () => {
+            offsetHeightStub.returns(1);
+
+            const component = renderIntoDocument(
+                <Truncate>
+                    Sample text
+                </Truncate>
+            );
+
+            expect(component.state.isVisible, 'to equal', true);
         });
 
         it('should recalculate when resizing the window', () => {

--- a/test/Truncate.js
+++ b/test/Truncate.js
@@ -111,7 +111,7 @@ describe('<Truncate />', () => {
             });
 
             // offset height is always 0 in jsdom world, so need to stub it out
-            Object.defineProperties(global.window.HTMLDivElement.prototype, {
+            Object.defineProperties(global.window.HTMLSpanElement.prototype, {
                 offsetHeight: {
                     get: offsetHeightStub
                 }


### PR DESCRIPTION
Fixes issue where if an element is hidden on the page, react-truncate will infinitely loop calling requestAnimationFrame taking up CPU. 

Solution is: If the target's parent isn't visible, don't try to calculate its width.

If there's a better solution, please feel free to comment, adjust commits.

Fixes issue #61 