### PR TITLE
Bugfix: conditional check around ellipsis removal to prevent errors in unexpected situations

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -80,7 +80,9 @@ export default class Truncate extends Component {
             timeout
         } = this;
 
-        ellipsis.parentNode.removeChild(ellipsis);
+        if (ellipsis && ellipsis.parentNode) {
+            ellipsis.parentNode.removeChild(ellipsis);
+        }
 
         window.removeEventListener('resize', onResize);
 


### PR DESCRIPTION
Fixes #128

Adds a conditional check around ellipsis removal in `ComponentWillUnmount` to help pass test suites and other situations where it might be missing