### PR TITLE
Delete width from spanProps

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -349,6 +349,7 @@ export default class Truncate extends Component {
 
         delete spanProps.onTruncate;
         delete spanProps.trimWhitespace;
+        delete spanProps.width;
 
         return (
             <span {...spanProps} ref={(targetEl) => { this.elements.target = targetEl; }}>


### PR DESCRIPTION
The width property is added as an attribute to the span tag:
`<span width="0">`
Attribute **width** not allowed on element [span](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-span-element) at this point.