### PR TITLE
Fix React warning about state update of unmounted component

### DIFF
--- a/src/Truncate.js
+++ b/src/Truncate.js
@@ -118,6 +118,7 @@ export default class Truncate extends Component {
             onTruncate
         } = this.props;
 
+        window.cancelAnimationFrame(this.timeout);
         if (typeof onTruncate === 'function') {
             this.timeout = window.requestAnimationFrame(() => {
                 onTruncate(didTruncate);


### PR DESCRIPTION
Hello,

I encountered the following React's warning when running unit tests for a component that is wrapping `react-truncate`:
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
```
I researched and found that the problem is related to non-canceled `requestAnimationFrame` callback which asynchronously calls a function specified in `onTruncate` prop.
The proposed change eliminates the warning.